### PR TITLE
Add preview event links

### DIFF
--- a/docs/event2023.html
+++ b/docs/event2023.html
@@ -104,15 +104,26 @@
 
           <div class="inner cover">
             <section class="giant-callout">
-              <span>Oct 21-22, 2023</span><br/>
-              <span>Online</span>
-              <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
+              <span>Online preview event!</span><br/>
+              <span>September 10, 2023</span>
+              <div><a href="https://ti.to/roguelike-celebration/preview-event-2023" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Get a free ticket!</a></div>
             </section>
           </div>
 
          <h1>When and Where?</h1>
          <p>
            Roguelike Celebration 2023 will be held on Saturday and Sunday <strong>October 21st and 22nd, 2023</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will also be streamed to Twitch and YouTube.
+         </p>
+         <p>
+           There will also be a free preview event <strong>September 10, 2023</strong> in the same social space, with talks streamed to Twitch and YouTube:
+         </p>
+         <ul>
+           <li>David Brevik will be joining us in a fireside chat style discussion about the development of <i>Diablo</i>!</li>
+           <li>Aron Pietroń and Michał Ogłoziński (Eremite Games) will be joining us in a fireside chat style discussion about <i>Against The Storm</i>!</li>
+           <li>Nic Junius will be presenting a talk: "Play as in Stage Play: Designing Dynamic Narrative Moments Through Character Acting"!</li>
+         </ul>
+         <p>
+           If you'd like to submit a question for our fireside chats, you can do so at <a href="https://docs.google.com/forms/d/e/1FAIpQLSeZNISZKNP3YpvsEA0ZIqTphe9wBBqj-f3rQ5Q7ajaP3HPGNg/viewform">this form</a>.
          </p>
          <h1>Our call for presenters is now closed.</h1>
          <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -150,6 +150,7 @@
           <section class="giant-callout">
             <span>Oct 21-22, 2023</span><br/>
             <span>Online</span>
+            <div><a href="https://ti.to/roguelike-celebration/preview-event-2023" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Get a free ticket to our preview event!<br>September 10th, 4pm Pacific</a></div>
             <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
           </section>
           


### PR DESCRIPTION
I just brought back what was done last year, but with dates and links updated.

I added a list of the talks to the event page (not sure if we want to update with speaker bios/links later), as well as links to the google form and the tito thing. Updated the index too.