### PR TITLE
Add schedule for 2023 preview event

### DIFF
--- a/docs/event2022.css
+++ b/docs/event2022.css
@@ -92,3 +92,9 @@ h2 {
     margin-top: 12px;
     margin-left: 12px;
 }
+
+#preview_schedule table, td, th {
+  border: 1px solid #fff;
+  padding: 1em;
+  white-space: nowrap;
+}

--- a/docs/event2023.html
+++ b/docs/event2023.html
@@ -105,30 +105,57 @@
           <div class="inner cover">
             <section class="giant-callout">
               <span>Online preview event!</span><br/>
-              <span>September 10, 2023</span>
+              <span><a href="https://dateful.com/convert/pst-pdt-pacific-time?t=4pm&d=2023-09-10">September 10, 2023, 4:00PM - 6:00PM Pacific</a></span>
               <div><a href="https://ti.to/roguelike-celebration/preview-event-2023" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Get a free ticket!</a></div>
             </section>
           </div>
 
-         <h1>When and Where?</h1>
-         <p>
-           Roguelike Celebration 2023 will be held on Saturday and Sunday <strong>October 21st and 22nd, 2023</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will also be streamed to Twitch and YouTube.
-         </p>
-         <p>
-           There will also be a free preview event <strong>September 10, 2023</strong> in the same social space, with talks streamed to Twitch and YouTube:
-         </p>
-         <ul>
-           <li>David Brevik will be joining us in a fireside chat style discussion about the development of <i>Diablo</i>!</li>
-           <li>Aron Pietroń and Michał Ogłoziński (Eremite Games) will be joining us in a fireside chat style discussion about <i>Against The Storm</i>!</li>
-           <li>Nic Junius will be presenting a talk: "Play as in Stage Play: Designing Dynamic Narrative Moments Through Character Acting"!</li>
-         </ul>
-         <p>
-           If you'd like to submit a question for our fireside chats, you can do so at <a href="https://docs.google.com/forms/d/e/1FAIpQLSeZNISZKNP3YpvsEA0ZIqTphe9wBBqj-f3rQ5Q7ajaP3HPGNg/viewform">this form</a>.
-         </p>
-         <h1>Our call for presenters is now closed.</h1>
-         <p>
-           Our talk submissions closed on July 15. 11:59pm PDT. If you submitted a talk, you'll hear back from us by email by the end of August.
-         </p>
+          <h1>When and Where?</h1>
+          <p>
+            Roguelike Celebration 2023 will be held on Saturday and Sunday <strong>October 21st and 22nd, 2023</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will also be streamed to Twitch and YouTube.
+          </p>
+          <p>
+            There will also be a free preview event <strong>September 10, 2023</strong> in the same social space, with talks streamed to Twitch and YouTube
+          </p>
+          <table id ="preview_schedule">
+            <thead>
+              <tr>
+                <th colspan="1">PDT</th>
+                <th colspan="1">CEST<br>(Mon)</th>
+                <th colspan="1">Preview Event Schedule</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>16:10</td>
+                <td>01:10</td>
+                <td>Introduction</td>
+              </tr>
+              <tr>
+                <td>16:15</td>
+                <td>01:15</td>
+                <td>David Brevik: a fireside chat style discussion about the development of <i>Diablo</i></td>
+              </tr>
+              <tr>
+                <td>16:50</td>
+                <td>01:50</td>
+                <td>Nic Junius: "Play as in Stage Play: Designing Dynamic Narrative Moments Through Character Acting"</td>
+              </tr>
+              <tr>
+                <td>17:25</td>
+                <td>02:25</td>
+                <td>Aron Pietroń and Michał Ogłoziński (Eremite Games): a fireside chat style discussion about <i>Against The Storm</i></td>
+              </tr>
+            </tbody>
+          </table>
+          <br>
+          <p>
+            If you'd like to submit a question for our fireside chats, you can do so at <a href="https://docs.google.com/forms/d/e/1FAIpQLSeZNISZKNP3YpvsEA0ZIqTphe9wBBqj-f3rQ5Q7ajaP3HPGNg/viewform">this form</a>.
+          </p>
+          <h1>Our call for presenters is now closed.</h1>
+          <p>
+            Our talk submissions closed on July 15. 11:59pm PDT. If you submitted a talk, you'll hear back from us by email by the end of August.
+          </p>
 
           <div class="mastfoot">
             <div class="inner">


### PR DESCRIPTION
Add schedule table.

Note that with 1 hour 45 minutes, split evenly, that's 35 minutes for each talk