### PR TITLE
CFP Closure for 2024 

### DIFF
--- a/docs/cfp.html
+++ b/docs/cfp.html
@@ -123,10 +123,9 @@
             </p>
 
             <div class="giant-callout">
-              <a href="https://forms.gle/WqHn8RQKqNSaMqWV7">
-                <button>Send us your idea!</button>
-              </a>
-              <p style="font-size: 3rem; margin-top: 10px; margin-bottom: 0">(by July 14, 11:59pm PDT)</p>
+              
+	    <p> Submissions are closed.</p>
+	    <p style="font-size: 3rem; margin-top: 10px; margin-bottom: 0">(July 14, 11:59pm PDT)</p> 
             </div>
 
             <h2>Tips For a Successful Proposal</h2>

--- a/docs/event2024.html
+++ b/docs/event2024.html
@@ -109,7 +109,6 @@
               <span>Oct 19-20, 2024</span><br/>
               <span>Online</span>
               <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
-              <div><a href="./cfp.html" class="btn btn-success btn-lg" role="button">Submit a talk proposal!</a></div>
             </section>
           </div>
 
@@ -117,9 +116,9 @@
          <p>
            Roguelike Celebration 2024 will be held on Saturday and Sunday <strong>October 19 - October 20, 2024</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will also be streamed to Twitch and YouTube.
          </p>
-         <h1>Our call for presenters is now open!</h1>
+         <h1>Our call for presenters has closed.</h1>
          <p>
-           Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances - we want to hear about it all! Submit a talk proposal <a href="./cfp.html">here</a>. The deadline for proposals is <strong>July 14, 2024.</strong>
+            The deadline for proposals was <strong>July 14, 2024.</strong>
          </p>
 
           <div class="mastfoot">

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,7 +153,6 @@
             <span>Oct 19-20, 2024</span><br/>
             <span>Online</span>
             <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
-            <div><a href="./cfp.html" class="btn btn-success btn-lg" role="button">Submit a talk proposal!</a></div>
           </section>
           
           <h1 id="thing" class="cover-heading">A celebration of roguelike games</h1>
@@ -165,7 +164,7 @@
             <button class="w3-button w3-display-right" onclick="plusDivs(+1)">&#10095;</button>
           </div>
           
-          <p>Roguelike Celebration 2024 is currently <a href="./cfp.html">accepting talk proposals</a>! The deadline for submissions is <strong>July 14, 2024.</strong>
+          <p>Roguelike Celebration 2024 is no longer accepting talk proposals. The deadline for submissions was <strong>July 14, 2024.</strong>
 
           <p>The Roguelike Celebration is a yearly community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It's for fans, players, developers, scholars, and everyone else!</p>
 


### PR DESCRIPTION
Landing page has been updated to remove link to CFP and change references to proposal date to past tense

2023 Event page  has been updated to remove link to CFP and change references to proposal date to past tense

Link to submission form on CFP page has been replaced to indicated submissions are closed.