### PR TITLE
Update CoC responder info

### DIFF
--- a/docs/code.html
+++ b/docs/code.html
@@ -103,13 +103,13 @@
             <li>Or if you're in our social/chat space, you can use the <strong>/mod</strong> command to send us a message.</li>
             </ul>
 
-            <p>Both of these methods reach the organizing team listed on the <a href="./who.html">About us page</a>, as well as the day-of moderation team. Our primary CoC responders for our 2022 event are <strong>Britta Gustafson</strong>, <strong>Rourke Bywater</strong>, and <strong>Travis Moy</strong>.</p>
+            <p>Both of these methods reach the organizing team listed on the <a href="./who.html">About us page</a>, as well as the day-of moderation team. Our primary CoC responders for our 2024 event are <strong>Rourke Bywater</strong> and <strong>Travis Moy</strong>.</p>
 
             <p>If you're not sure whether something is a Code of Conduct problem, please reach out &mdash; we want to hear your concerns and do our best to reduce harm to this community.</p>
 
             <p>We will acknowledge your message ASAP, work quickly to determine an appropriate response, and let you know our response. For example, if an event attendee harasses or disrupts people, we may revoke their event ticket and ban them from future events.</p>
 
-            <p>If you have a report or concern related to an organizer, please contact a different organizer directly, such as by emailing brittag@gmail.com, rourkebywater@gmail.com, or moytravis@gmail.com.</p>
+            <p>If you have a report or concern related to an organizer, please contact a different organizer directly, such as by emailing rourkebywater@gmail.com or moytravis@gmail.com.</p>
 
            <h2>Definitions</h2>
 

--- a/docs/who.html
+++ b/docs/who.html
@@ -99,8 +99,8 @@
 
             <h3 style="display: block;">2024 Moderator Contact Info</h3>
             <p>If you need to talk to a mod, either type /mod in the social space with your message, email us at contact@roguelike.club, or email one of our mods directly. See our <a href="./code.html">Code of Conduct</a> page for more details.</p>
-            <p>Our primary CoC responders for our 2024 preview event are <strong>Britta Gustafson</strong>, <strong>Rourke Bywater</strong>, and <strong>Travis Moy</strong>.</p>
-            <p>If you have a report or concern related to an organizer, please contact a different organizer directly, such as by emailing brittag@gmail.com, rourkebywater@gmail.com, or moytravis@gmail.com.</p>
+            <p>Our primary CoC responders for our 2024 preview event are <strong>Rourke Bywater</strong> and <strong>Travis Moy</strong>.</p>
+            <p>If you have a report or concern related to an organizer, please contact a different organizer directly, such as by emailing rourkebywater@gmail.com or moytravis@gmail.com.</p>
 
             <h3 style="display: block;">Current Organizers</h3>
 
@@ -110,7 +110,6 @@
 
             <img class="headshot" src="photos/2021/BrittaGustafson.jpg"/>
             <h3><a href="https://twitter.com/brittagus">Britta Gustafson</a></h3>
-            <p><em>To contact me directly to report a <a href="./code.html">Code of Conduct</a> concern, email brittag@gmail.com</em></p>
             <p><a href="https://twitter.com/ampepers/status/1180536770183626752" target="_blank">(Paladin)</a> I've been playing Nethack since I was a kid, when I found it on a Mac OS 8 shareware games site. I like helping make things happen; I ran <a href="https://www.theiphonewiki.com/wiki/JailbreakCon">conferences</a> as part of an old job, and I help run a <a href="https://www.doubleunion.org/">nonprofit hackerspace</a> for fun.</p>
 
             <!-- <img class="headshot" src="photos/2021/silhouette.png"/>


### PR DESCRIPTION
We'd updated the list on the team page but not on the CoC page itself. Also removing myself from "primary" CoC responder status this year.