### PR TITLE
Add link to CFP from main page

### DIFF
--- a/docs/cfp.html
+++ b/docs/cfp.html
@@ -121,16 +121,16 @@
       <div class="site-wrapper-inner">
         <div class="cover-container">
           <div class="inner cover">
-            <h1 id="cfp" class="cover-heading">Call for presenters</h1>
+            <h1 id="cfp" class="cover-heading">Call for Presenters</h1>
 
-            <p>Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances - we want to hear about it all!
-            </p>
+            <p>Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances – we want to hear about it all!</p>
 
             <div class="giant-callout">
-              
-	    <p>Call For Proposals</p>
-	    <p style="font-size: 3rem; margin-top: 10px; margin-bottom: 0">Open until June 30, 2025</p> 
-      <div><a href=" https://forms.gle/xcJjpvJybksseyqR6" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Send us your idea!</a></div>
+  	          <p>Call For Proposals</p>
+	            <p style="font-size: 3rem; margin-top: 10px; margin-bottom: 0">Open until June 30, 2025</p> 
+              <div>
+                <a href="https://forms.gle/xcJjpvJybksseyqR6" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Send us your idea!</a>
+              </div>
             </div>
 
             <h2>Submit a Proposal</h2>
@@ -140,14 +140,16 @@
             </p>
 
             <h2>Tips For a Successful Proposal</h2>
+
             <p>
-              We get more proposals for Roguelike Celebration every year than we can accept - and we decided it would be helpful to provide some guidelines for what is more likely to get your proposal accepted. We want to help make sure your proposal expresses the best things about your talk, and to make clear what types of talks might not fit our conference and are likely to be rejected.
+              We get more proposals for Roguelike Celebration every year than we can accept – and we decided it would be helpful to provide some guidelines for what is more likely to get your proposal accepted. We want to help make sure your proposal expresses the best things about your talk, and to make clear what types of talks might not fit our conference and are likely to be rejected.
             </p>
             <p>
-              These tips are based on past years and what led to the decisions we made - but do keep in mind they’re just guidelines! Exceptions always exist and if you’re passionate about a particular idea, we’d love to see it.
+              These tips are based on past years and what led to the decisions we made – but do keep in mind they’re just guidelines! Exceptions always exist and if you’re passionate about a particular idea, we’d love to see it.
             </p>
 
             <h3>Common Pitfalls in a Talk Proposal</h3>
+
             <div class="pitfalls">
             <div class="row header">
               <div class="col-xs-6">
@@ -163,7 +165,7 @@
                 It’s just a general retrospective about making your game or telling a straightforward story about what your game is.
               </div>
               <div class="col-xs-6">
-                Better to focus more on a specific theme, insight, or design ethos - give your talk a unique frame.
+                Better to focus more on a specific theme, insight, or design ethos – give your talk a unique frame.
               </div>
             </div>
 
@@ -181,7 +183,7 @@
                 Your game or ideas are still in development and still vague.
               </div>
               <div class="col-xs-6">
-                Sometimes this is ok when there’s a unique aspect, but sometimes it's better to propose it again next year after you’ve developed it further or shipped.
+                Sometimes this is ok when there’s a unique aspect, but sometimes it’s better to propose it again next year after you’ve developed it further or shipped.
               </div>
             </div>
 
@@ -217,7 +219,7 @@
                 Your proposal is very similar to past talks.
               </div>
               <div class="col-xs-6">
-                The more similar your proposal is to a past talk, the more you should talk about what makes *your* take different. We like different angles on similar topics but variety is also important!
+                The more similar your proposal is to a past talk, the more you should talk about what makes <strong>your</strong> take different. We like different angles on similar topics but variety is also important!
               </div>
             </div>
 
@@ -225,43 +227,49 @@
 
           <h3>Tips for a Great Proposal</h3>
 
-          <h4>Make it <strong>your</strong> talk</h4>
-          <p>A great talk is one that no one else could give because it’s linked to your own experiences, perspectives, and ideas! This isn’t about your credentials - we want a sense of what you as a person bring to your talk.</p>
+          <h4>Make It <em>Your</em> Talk</h4>
+          <p>A great talk is one that no one else could give because it’s linked to your own experiences, perspectives, and ideas! This isn’t about your credentials – we want a sense of what you as a person bring to your talk.</p>
 
           <h4>Be Specific!</h4>
-          <p>Giving your audience a teaser that leaves them with more questions can be fun, but not for your proposal. We don’t need a breakdown of every point you’re making, but we *do* need to know your overarching idea and where you’re taking it.</p>
+          <p>Giving your audience a teaser that leaves them with more questions can be fun, but not for your proposal. We don’t need a breakdown of every point you’re making, but we <strong>do</strong> need to know your overarching idea and where you’re taking it.</p>
 
           <h4>Know Your Audience</h4>
-          <p>One lens we use for talks is “who is going to find this interesting and what are they going to take away from this talk?” The clearer you know this yourself and tell us, the better! It’s okay if the takeaway isn’t a literal skill but is a feeling like being inspired or amused - Just be intentional.</p>
+          <p>One lens we use for talks is “who is going to find this interesting and what are they going to take away from this talk?” The clearer you know this yourself and tell us, the better! It’s okay if the takeaway isn’t a literal skill but is a feeling like being inspired or amused – Just be intentional.</p>
 
           <h4>Don’t Rely on Deep Familiarity With Specific Games</h4>
           <p>Whether it’s your game or a classic you love, you can’t count on everyone having played it. It’s fine to still focus on particular games but make sure people who don’t know it as well as you can still follow along and get something out of your talk.</p>
 
           <h4>Don’t Sell Yourself Short!</h4>
-          <p>We’re an oddball mix of people who do this because we love it, not because we think we’re amazing at it or the most qualified people in the world. So it’s fine if that’s you too - try not to talk down at yourself or second guess your own proposal.</p>
+          <p>We’re an oddball mix of people who do this because we love it, not because we think we’re amazing at it or the most qualified people in the world. So it’s fine if that’s you too – try not to talk down at yourself or second guess your own proposal.</p>
 
           <h4>... And Don’t Rely Just on Credentials</h4>
           <p>If you made a great game or are a full time speaker that’s awesome to know, but we still need to evaluate your idea itself! Don’t spend too much time listing out your bona fides, just let us know the highlights then get into why your talk will be great.</p>
 
           <h3>Example of an Accepted Submission</h3>
-            <p>As an organizer, Alexei has agreed to share her 2018 talk submission for “Nethack: Tech Tourist Mode” as an example of a submission that was accepted. It’s useful to note that this proposal deals with a single game and a personal project, both potential issues. What counters those issues is the proposal explicitly saying what the audience is expected to get out of it, including people who don’t know Nethack. Discussion with the organizers led to the decision to turn it into a full talk, partly so that the aspect of “the benefits of exploring source code in general” could be fleshed out.
-            </p>
 
-            <p><strong>Bio:</strong>
-            <br>A professional game designer and programmer from Edmonton, I inherited a love of Nethack from my mother and have been interested in roguelikes my whole life. I previously worked in the Nethack codebase to research how roguelikes could be made more accessible for visually impaired players, and presented my findings at the first Roguelike Celebration.
-            </p>
+          <p>As an organizer, Alexei has agreed to share her 2018 talk submission for <a href="https://www.youtube.com/watch?v=5y_IAdOwaYs&list=PLi7jNGNQhwdisqRtuvX8X8Q2F0TEUgQ5V&index=8">“Nethack: Tech Tourist Mode”</a> as an example of a submission that was accepted. It’s useful to note that this proposal deals with a single game and a personal project, both potential issues. What counters those issues is the proposal explicitly saying what the audience is expected to get out of it, including people who don’t know Nethack. Discussion with the organizers led to the decision to turn it into a full talk, partly so that the aspect of “the benefits of exploring source code in general” could be fleshed out.
+          </p>
+          <p>Here's Alexei’s submission:</p>
 
-            <p><strong>Talk Title:</strong>
-            <br>Nethack: Tech Tourist Mode
-            </p>
+          <hr/>
 
-            <p><strong>What would you like to present on? *</strong>
-            <br>A guided tour of the Nethack codebase, highlighting areas of particular interest or amusement. When I was working in the Nethack code for my research I found a lot of interesting tidbits I'd like to share with people who lack the time or technical know-how to go digging through the code themselves. I could do this as a short 10 minute talk that just speeds through some highlights, or I think there's enough of it to spin into more of a 20 minute talk, potentially bringing in some discussion of how someone could play with the Nethack code themselves, or generally the fun of browsing the source for your favourite roguelike.
-            </p>
+          <p><strong>Bio:</strong>
+          <br>A professional game designer and programmer from Edmonton, I inherited a love of Nethack from my mother and have been interested in roguelikes my whole life. I previously worked in the Nethack codebase to research how roguelikes could be made more accessible for visually impaired players, and presented my findings at the first Roguelike Celebration.
+          </p>
 
-            <p><strong>Do you have anything else to share about your proposal?</strong>
-            <br>I presented my work on making roguelikes more accessible for visually impaired players at the first Roguelike Celebration (a presentation which I also gave in a couple other contexts). I've continued to do other talks on various subjects, such as chaos theory (which I'm submitting another talk proposal in relation to), and how to start making video games.
-            </p>
+          <p><strong>Talk Title:</strong>
+          <br>Nethack: Tech Tourist Mode
+          </p>
+
+          <p><strong>What would you like to present on? *</strong>
+          <br>A guided tour of the Nethack codebase, highlighting areas of particular interest or amusement. When I was working in the Nethack code for my research I found a lot of interesting tidbits I'd like to share with people who lack the time or technical know-how to go digging through the code themselves. I could do this as a short 10 minute talk that just speeds through some highlights, or I think there's enough of it to spin into more of a 20 minute talk, potentially bringing in some discussion of how someone could play with the Nethack code themselves, or generally the fun of browsing the source for your favourite roguelike.
+          </p>
+
+          <p><strong>Do you have anything else to share about your proposal?</strong>
+          <br>I presented my work on making roguelikes more accessible for visually impaired players at the first Roguelike Celebration (a presentation which I also gave in a couple other contexts). I've continued to do other talks on various subjects, such as chaos theory (which I'm submitting another talk proposal in relation to), and how to start making video games.
+          </p>
+
+          <hr/>
           </div> 
 
           <div class="mastfoot">

--- a/docs/cfp.html
+++ b/docs/cfp.html
@@ -133,6 +133,12 @@
       <div><a href=" https://forms.gle/xcJjpvJybksseyqR6" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Send us your idea!</a></div>
             </div>
 
+            <h2>Submit a Proposal</h2>
+
+            <p>
+              To submit a talk proposal, <a href="https://forms.gle/xcJjpvJybksseyqR6">fill out our CFP form</a> by June 30, 2025.
+            </p>
+
             <h2>Tips For a Successful Proposal</h2>
             <p>
               We get more proposals for Roguelike Celebration every year than we can accept - and we decided it would be helpful to provide some guidelines for what is more likely to get your proposal accepted. We want to help make sure your proposal expresses the best things about your talk, and to make clear what types of talks might not fit our conference and are likely to be rejected.

--- a/docs/event2025.html
+++ b/docs/event2025.html
@@ -121,8 +121,8 @@
          </p>
          <h1>Our call for presenters is <strong>open until June 30, 2025</strong>!</h1>
          <p>
-           Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances - we want to hear about it all!
-           <br/>For updates leading up to the conference, you can sign up to our mailing list.
+           Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances – we want to hear about it all! See the <a href="./cfp.html">Call for Proposals</a> for details and submission links.
+         </p>
          </p>
 
           <div class="mastfoot">

--- a/docs/event2025.html
+++ b/docs/event2025.html
@@ -119,10 +119,15 @@
          <p>
            Roguelike Celebration 2025 will be held on Saturday and Sunday <strong>October 25 - October 26, 2025</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will also be streamed to Twitch and YouTube.
          </p>
+
          <h1>Our call for presenters is <strong>open until June 30, 2025</strong>!</h1>
          <p>
            Technical talks, game design lessons, creative uses of procedural generation, interactive roguelike performances – we want to hear about it all! See the <a href="./cfp.html">Call for Proposals</a> for details and submission links.
          </p>
+
+         <h1>Get Updates</h1>
+         <p>
+           For updates leading up to the conference, you can sign up to our <a href="https://buttondown.email/RoguelikeCelebration">mailing list</a>.
          </p>
 
           <div class="mastfoot">

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,6 +211,9 @@
           <p>Is your organization interested in sponsoring Roguelike Celebration? Check out our <a
               href="./sponsor.html">sponsorship
               page</a>!</p>
+          <h1 id="speakers" class="cover-heading">Want to give a talk?</h1>
+
+          <p>Our <a href="cfp.html">2025 Call for Proposals</a> is now open! If you'd like to give a talk, see it for details.</p>
 
           <h1>Why?</h1>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -200,17 +200,17 @@
 
           <p>We're also on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
 
- <h1 id="sponsors" class="cover-heading">Sponsors</h1>
+          <h1 id="sponsors" class="cover-heading">Sponsors</h1>
 
-          <p style="text-align: center"><a href="https://www.artsandmedia.net"><img
-                src="sponsors/IAM-Logo-White-Blue-Transparent-Background.png" alt="Independent Arts & Media logo" height="37" /></a>
+          <p style="text-align: center">
+            <a href="https://www.artsandmedia.net">
+              <img src="sponsors/IAM-Logo-White-Blue-Transparent-Background.png" alt="Independent Arts & Media logo" height="37" /></a>
             <br />
             Roguelike Celebration is <a href="https://en.wikipedia.org/wiki/Fiscal_sponsorship">fiscally sponsored</a> by <a href="https://www.artsandmedia.net">Independent Arts & Media</a>, a 501(c)(3) nonprofit organization.
-          <br />
+            <br /></p>
 
-          <p>Is your organization interested in sponsoring Roguelike Celebration? Check out our <a
-              href="./sponsor.html">sponsorship
-              page</a>!</p>
+          <p>Is your organization interested in sponsoring Roguelike Celebration? Check out our <a href="./sponsor.html">sponsorship page</a>!</p>
+
           <h1 id="speakers" class="cover-heading">Want to give a talk?</h1>
 
           <p>Our <a href="cfp.html">2025 Call for Proposals</a> is now open! If you'd like to give a talk, see it for details.</p>
@@ -221,7 +221,7 @@
             our hearts. There are so many fans across age groups and around the world that there should be a place for
             all of them to get together and celebrate these unique games.</p>
           <p>We were inspired to do this by the <a href="http://www.roguebasin.com/index.php?title=IRDC">International
-              Roguelike Development Conference</a> — and instead of a focus on development, this is for all of us — the
+            Roguelike Development Conference</a> — and instead of a focus on development, this is for all of us — the
             players!</p>
 
           <p><img src="./ticket-front-25.png" alt="ticket image" style="width: 630px; max-width: 100%;" /></p>


### PR DESCRIPTION
Adds a link to the CFP from the main page. (Doesn't seem to be one now.) Also adds more links to CFP and the form in body text on CFP page etc., in case folks skim over bright buttons like I do.

Also minor HTML and content formatting, to make it more consistent with what looks like the overall prevailing style here.

## Details

Formatting changes:

* CFP page
  * In Alexei's accepted-proposal example, add a link to the talk's video.
  * Use curly apostrophe (’) and en dash (–) in more places.
  * Capitalize "Call for Presenters" and "Make It *Your* Talk" headings, for consistency with other headings at those levels.
  * Add hr's around Alexei's example proposal to distinguish that quoted text from the rest of the page.
  * Use italics instead of bold for "Make It *Your* Talk"'s "*Your*", because bolding isn't very visible in that header level's heavy text.
* event2025 page
  * Add a "Get Updates" header for the mailing list link, so it stands out from the CFP submission paragraph. (I think we want it to stick out as an option for people who didn't go ahead and submit a CFP, too?)
* Indentation of some HTML for within-page consistency in various pages.