### PR TITLE
Nav bar fixes: missing items, update speakers202*, prior-year active items, HTML indentation

### DIFF
--- a/docs/event.html
+++ b/docs/event.html
@@ -48,7 +48,7 @@
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
                 <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
                 <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-                <li><a class="dropdown-item" href="./event.html">2016</a></li>
+                <li class="active"><a class="dropdown-item" href="./event.html">2016</a></li>
               </ul>
           </li>
           <li><a href="./who.html">About us</a></li>
@@ -75,7 +75,7 @@
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
             <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
             <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-            <li><a class="dropdown-item" href="./event.html">2016</a></li>
+            <li class="active"><a class="dropdown-item" href="./event.html">2016</a></li>
           </ul>
         </div>
       </nav>

--- a/docs/event2017.html
+++ b/docs/event2017.html
@@ -48,7 +48,7 @@
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
                 <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-                <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2017.html">2017</a></li>
                 <li><a class="dropdown-item" href="./event.html">2016</a></li>
               </ul>
           </li>
@@ -75,7 +75,7 @@
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
             <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-            <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2017.html">2017</a></li>
             <li><a class="dropdown-item" href="./event.html">2016</a></li>
           </ul>
         </div>

--- a/docs/event2018.html
+++ b/docs/event2018.html
@@ -47,7 +47,7 @@
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-                <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2018.html">2018</a></li>
                 <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
                 <li><a class="dropdown-item" href="./event.html">2016</a></li>
               </ul>
@@ -74,7 +74,7 @@
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-            <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2018.html">2018</a></li>
             <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
             <li><a class="dropdown-item" href="./event.html">2016</a></li>
           </ul>

--- a/docs/event2019.html
+++ b/docs/event2019.html
@@ -61,7 +61,7 @@
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-                <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2019.html">2019</a></li>
                 <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
                 <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
                 <li><a class="dropdown-item" href="./event.html">2016</a></li>
@@ -88,7 +88,7 @@
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-            <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2019.html">2019</a></li>
             <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
             <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
             <li><a class="dropdown-item" href="./event.html">2016</a></li>

--- a/docs/event2020.html
+++ b/docs/event2020.html
@@ -426,7 +426,7 @@ When not working on games, I love rock climbing, reading fantasy and sci-fi, and
 
           </div>
 
-<h1 id="sponsors" class="cover-heading">Sponsors</h1>
+          <h1 id="sponsors" class="cover-heading">Sponsors</h1>
 
             <p style="text-align: center"><a href="https://www.noisebridge.net/"><img src="sponsors/NB-logo-red-black-med.png" alt="Noisebridge logo" height="37" /><img src="sponsors/NoisebridgeCursive.png" height="37" alt="Noisebridge word logo" /></a><br/>Roguelike Celebration 2020 was sponsered by <a href="https://www.noisebridge.net/">Noisebridge</a>, a hackerspace for technical-creative projects, doocratically run by its members. It is a non-profit educational institution intended for public benefit. We're grateful for their service as our 2020 <a href="https://en.wikipedia.org/wiki/Fiscal_sponsorship">fiscal sponsor</a>.</p>
 

--- a/docs/event2020.html
+++ b/docs/event2020.html
@@ -60,7 +60,7 @@
                 <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-                <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2020.html">2020</a></li>
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
                 <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
                 <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
@@ -87,7 +87,7 @@
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-            <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2020.html">2020</a></li>
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
             <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
             <li><a class="dropdown-item" href="./event2017.html">2017</a></li>

--- a/docs/event2020preview.html
+++ b/docs/event2020preview.html
@@ -49,13 +49,15 @@
       <nav class="hidden-xs hidden-sm">
         <ul class="nav masthead-nav">
           <li><a href="./">Intro</a></li>
-          <li><a href="./event2023.html">2023</a></li>
+          <li><a href="./event2025.html">2025</a></li>
           <li class="active dropdown">
               <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 Previous Years
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -76,11 +78,13 @@
           <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
           <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
             <li><a href="./">Intro</a></li>
-            <li><a href="./event2023.html">2023</a></li>
+            <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -92,6 +96,7 @@
         </div>
       </nav>
     </div>
+
 
     <div class="site-wrapper">
 
@@ -160,9 +165,9 @@
               <a href="javascript:bio(8);">(bio)</a></td></tr>
               <tr id="bio_8" class="bio hidden"><td></td><td style="padding-left: 20px;"><i>"I'm the CEO and founder of Flint Games, a small indie part-time game studio. I've only just made the leap to full time, and will be founding a new studio later this summer.
 
-In the past, I've worked on many commercial games that millions of users have played, such as Lumosity, BlitzKeep, We Rule, GodFinger, Quests and Sorcery, display.land, and more.
+                In the past, I've worked on many commercial games that millions of users have played, such as Lumosity, BlitzKeep, We Rule, GodFinger, Quests and Sorcery, display.land, and more.
 
-When not working on games, I love rock climbing, reading fantasy and sci-fi, and writing fantasy and sci-fi."</i></td></tr>
+                When not working on games, I love rock climbing, reading fantasy and sci-fi, and writing fantasy and sci-fi."</i></td></tr>
               <tr style="height: 1px;"><td colspan="2" style="background-color: #888;"></div></td></tr>
 
               <tr><td><em>6:10</em></td><td>Social Time</td></tr>

--- a/docs/event2021.html
+++ b/docs/event2021.html
@@ -62,7 +62,7 @@
                 <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
                 <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-                <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
                 <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
@@ -89,7 +89,7 @@
             <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-            <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
             <li><a class="dropdown-item" href="./event2018.html">2018</a></li>

--- a/docs/event2022.html
+++ b/docs/event2022.html
@@ -62,7 +62,7 @@
               <ul class="dropdown-menu" aria-labelledby="drop1">
                 <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
                 <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-                <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
                 <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
@@ -89,7 +89,7 @@
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
             <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-            <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
             <li><a class="dropdown-item" href="./event2019.html">2019</a></li>

--- a/docs/event2023.html
+++ b/docs/event2023.html
@@ -61,7 +61,7 @@
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
                 <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -88,7 +88,7 @@
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
             <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+            <li class="active><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>

--- a/docs/event2024.html
+++ b/docs/event2024.html
@@ -78,7 +78,7 @@
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
-                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li class="active"><a class="dropdown-item" href="./event2024.html">2024</a></li>
                 <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
@@ -105,7 +105,7 @@
             <li><a href="./code.html">CoC</a></li>
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
-            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li class="active"><a class="dropdown-item" href="./event2024.html">2024</a></li>
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>

--- a/docs/event2025.html
+++ b/docs/event2025.html
@@ -73,6 +73,7 @@
           </li>
           <li><a href="./who.html">About us</a></li>
           <li><a href="./code.html">CoC</a></li>
+          <li><a href="./sponsor.html">Sponsorship</a></li>
           <li><a href="./roguelikes.html">Roguelikes?</a></li>
         </ul>
       </nav>
@@ -84,6 +85,7 @@
             <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
             <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>

--- a/docs/github-coc.html
+++ b/docs/github-coc.html
@@ -30,11 +30,8 @@
   <body>
 
     <div class="site-wrapper">
-
       <div class="site-wrapper-inner">
-
         <div class="cover-container">
-
           <div class="masthead clearfix">
             <div class="inner">
               <h3 class="masthead-brand">Roguelike Celebration @@@</h3>
@@ -89,25 +86,25 @@
             <p>Our goal in dealing with reported incidents is to assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
           </div>
 
-                    <div class="mastfoot">
-                      <div class="inner">
-                        <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
-                      </div>
-                    </div>
+          <div class="mastfoot">
+            <div class="inner">
+              <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
+            </div>
+          </div>
 
-                  </div>
+        </div>
 
-                </div>
+      </div>
 
-              </div>
+    </div>
 
-              <!-- Bootstrap core JavaScript
-              ================================================== -->
-              <!-- Placed at the end of the document so the pages load faster -->
-              <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-              <script>window.jQuery || document.write('<script src="./docs/assets/js/vendor/jquery.min.js"><\/script>')</script>
-              <script src="/dist/js/bootstrap.min.js"></script>
-              <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-              <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
-            </body>
-          </html>
+    <!-- Bootstrap core JavaScript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="./docs/assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script src="/dist/js/bootstrap.min.js"></script>
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,269 +1,264 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <meta http-equiv="cache-control" content="max-age=3600" />
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-  <meta name="description" content="">
-  <meta name="author" content="">
-  <meta http-equiv="cache-control" content="max-age=3600" />
-  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <title>Roguelike Celebration</title>
 
-  <title>Roguelike Celebration</title>
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
 
-  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+    <!-- Bootstrap core CSS -->
+    <link href="./dist/css/bootstrap.min.css" rel="stylesheet">
 
-  <!-- Bootstrap core CSS -->
-  <link href="./dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <link href="./docs/assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
 
-  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-  <link href="./docs/assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <!-- Custom styles for this template -->
+    <link href="cover.css" rel="stylesheet">
 
-  <!-- Custom styles for this template -->
-  <link href="cover.css" rel="stylesheet">
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+      <![endif]-->
 
-  <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-  <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script>
+      var slideIndex = 1;
+      var justChanged = false;
+      var maxSlides = 21;
+      setTimeout(() => {
+        showDivs(slideIndex);
+      });
 
-  <script>
-    var slideIndex = 1;
-    var justChanged = false;
-    var maxSlides = 21;
-    setTimeout(() => {
-      showDivs(slideIndex);
-    });
+      setInterval(() => {
+        if (justChanged) {
+          justChanged = false;
+        } else {
+          showDivs(slideIndex += 1);
+        }
+      }, 4000);
 
-    setInterval(() => {
-      if (justChanged) {
-        justChanged = false;
-      } else {
-        showDivs(slideIndex += 1);
+      function plusDivs(n) {
+        justChanged = true;
+        showDivs(slideIndex += n);
       }
-    }, 4000);
 
-    function plusDivs(n) {
-      justChanged = true;
-      showDivs(slideIndex += n);
-    }
+      function showDivs(n) {
+        var i;
+        var x = document.getElementsByClassName("mySlides");
+        x[0].style.position = "relative";
+        if (n > x.length) {
+          slideIndex = 1
+        }
+        if (n < 1) {
+          slideIndex = x.length
+        };
+        for (i = 0; i < x.length; i++) {
+          // x[i].style.display = "none";
+          x[i].style.opacity = 0;
+        }
+        // x[slideIndex - 1].style.display = "block";
+        x[slideIndex - 1].style.opacity = 1;
 
-    function showDivs(n) {
-      var i;
-      var x = document.getElementsByClassName("mySlides");
-      x[0].style.position = "relative";
-      if (n > x.length) {
-        slideIndex = 1
-      }
-      if (n < 1) {
-        slideIndex = x.length
-      };
-      for (i = 0; i < x.length; i++) {
-        // x[i].style.display = "none";
-        x[i].style.opacity = 0;
-      }
-      // x[slideIndex - 1].style.display = "block";
-      x[slideIndex - 1].style.opacity = 1;
-
-      if (x.length < maxSlides && n >= x.length - 3) {
-        for (var i = x.length + 1; i < n + 3; i++) {
-          $('<img class="mySlides" src="./photos/slideshow/' + i + '.jpg" />').insertAfter(
-            "#slidesContainer > img:last");
+        if (x.length < maxSlides && n >= x.length - 3) {
+          for (var i = x.length + 1; i < n + 3; i++) {
+            $('<img class="mySlides" src="./photos/slideshow/' + i + '.jpg" />').insertAfter(
+              "#slidesContainer > img:last");
+          }
         }
       }
-    }
-  </script>
+    </script>
 
-  <script>
-    var currentBio;
-    function bio(val) {
-      if (currentBio) {
-        $("#bio_" + currentBio).addClass("hidden").removeClass("anim");
+    <script>
+      var currentBio;
+      function bio(val) {
+        if (currentBio) {
+          $("#bio_" + currentBio).addClass("hidden").removeClass("anim");
+        }
+        if (currentBio != val) {
+          currentBio = val;
+          $("#bio_" + currentBio).removeClass("hidden").addClass("anim");
+        } else {
+          currentBio = undefined;
+        }
       }
-      if (currentBio != val) {
-        currentBio = val;
-        $("#bio_" + currentBio).removeClass("hidden").addClass("anim");
-      } else {
-        currentBio = undefined;
-      }
-    }
-  </script>
-</head>
+    </script>
+  </head>
 
-<body>
-  <!-- gini was here -->
-  <div class="masthead clearfix">
-    <h3 class="masthead-brand">Roguelike Celebration</h3>
-    <nav class="hidden-xs hidden-sm">
-      <ul class="nav masthead-nav">
-        <li class="active"><a href="./">Intro</a></li>
-        <li><a href="./event2025.html">2025</a></li>
-        <li class="dropdown">
-            <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              Previous Years
-              <span class="caret"></span>
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="drop1">
-              <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-              <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-              <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-              <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-              <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-              <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-              <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-              <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-              <li><a class="dropdown-item" href="./event.html">2016</a></li>
-            </ul>
-        </li>
-        <li><a href="./who.html">About us</a></li>
-        <li><a href="./code.html">CoC</a></li>
-        <li><a href="./sponsor.html">Sponsorship</a></li>
-        <li><a href="./roguelikes.html">Roguelikes?</a></li>
-      </ul>
-    </nav>
-    <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
-      <div class="dropdown">
-        <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
-        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
-          <li><a href="./">Intro</a></li>
+  <body>
+    <!-- gini was here -->
+    <div class="masthead clearfix">
+      <h3 class="masthead-brand">Roguelike Celebration</h3>
+      <nav class="hidden-xs hidden-sm">
+        <ul class="nav masthead-nav">
+          <li class="active"><a href="./">Intro</a></li>
           <li><a href="./event2025.html">2025</a></li>
+          <li class="dropdown">
+              <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                Previous Years
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+                <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+                <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+                <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+                <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+                <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+                <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+                <li><a class="dropdown-item" href="./event.html">2016</a></li>
+              </ul>
+          </li>
           <li><a href="./who.html">About us</a></li>
           <li><a href="./code.html">CoC</a></li>
           <li><a href="./sponsor.html">Sponsorship</a></li>
           <li><a href="./roguelikes.html">Roguelikes?</a></li>
-          <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-          <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-          <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-          <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-          <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-          <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-          <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-          <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-          <li><a class="dropdown-item" href="./event.html">2016</a></li>
         </ul>
-      </div>
-    </nav>
-  </div>
-  <div class="site-wrapper">
-    <div class="site-wrapper-inner">
-      <div class="cover-container">
-        <div class="inner cover">
-          <section class="giant-callout">
-            <span>Main Event</span><br/>
-            <span>Oct 25-26, 2025</span><br/>
-            <span>Online</span>
-            <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
-            <div><a href="./cfp.html" class="btn btn-success btn-lg" role="button">Submit a talk proposal!</a></div>
-          </section>
-          <h1 id="thing" class="cover-heading">A celebration of roguelike games</h1>
-          
-          <div class="slidesContainer" id="slidesContainer">
-            <img class="mySlides" src="./photos/slideshow/1.jpg">
-            <img class="mySlides" src="./photos/slideshow/2.jpg">
-            <button class="w3-button w3-display-left" onclick="plusDivs(-1)">&#10094;</button>
-            <button class="w3-button w3-display-right" onclick="plusDivs(+1)">&#10095;</button>
-          </div>
-
-          <p>
-            Roguelike Celebration 2025 will be held on Saturday and Sunday <strong>October 25 - October 26, 2025</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will be streamed to Twitch and YouTube, and made available on YouTube shortly afterwards.
-          </p>
-
-          <p>The Roguelike Celebration is a yearly community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It's for fans, players, developers, scholars, and everyone else!</p>
-
-          <p>Roguelike games have been part of gaming culture for over 30 years and they have a deep and special place in our hearts. Over the last few years hundreds of roguelike fans got together to celebrate these games and their rich history, and we keep doing it again every October.</p>
-
-          <p>To make things feel particularly rogue-y, we host our virtual events in our own custom-built multiplayer game/chat space (<a href="https://github.com/Roguelike-Celebration/azure-mud">which is open source</a>). All you need to attend Roguelike Celebration is a web browser.</p>
-
-          <h1 id="updates" class="cover-heading">Want to get updates?</h1>
-
-          <h2>Email</h2>
-
-          <p>Sign up for occasional email announcements and updates about upcoming Roguelike Celebration events.</p>
-          <p><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Subscribe for updates!</a></p>
-
-          <h2>Twitter</h2>
-
-          <p>Use the <a href="https://twitter.com/search?q=%23roguelikecelebration&amp;f=liven">#RoguelikeCelebration</a> hashtag on twitter!
-          </p>
-
-          <p>Follow us on Twitter: <a href="https://twitter.com/roguelike_con">@roguelike_con</a></p>
-
-          <h2>Mastodon / The Fediverse</h2>
-          
-          <p>Follow us on Mastodon: <a rel="me" href="https://mastodon.gamedev.place/@roguelike_con">@roguelike_con@mastodon.gamedev.place</a></p>
-
-          <h2>Bluesky</h2>
-
-          <p>We're also on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
-
-          <h1 id="sponsors" class="cover-heading">Sponsors</h1>
-
-          <p style="text-align: center">
-            <a href="https://www.artsandmedia.net">
-              <img src="sponsors/IAM-Logo-White-Blue-Transparent-Background.png" alt="Independent Arts & Media logo" height="37" /></a>
-            <br />
-            Roguelike Celebration is <a href="https://en.wikipedia.org/wiki/Fiscal_sponsorship">fiscally sponsored</a> by <a href="https://www.artsandmedia.net">Independent Arts & Media</a>, a 501(c)(3) nonprofit organization.
-            <br /></p>
-
-          <p>Is your organization interested in sponsoring Roguelike Celebration? Check out our <a href="./sponsor.html">sponsorship page</a>!</p>
-
-          <h1 id="speakers" class="cover-heading">Want to give a talk?</h1>
-
-          <p>Our <a href="cfp.html">2025 Call for Proposals</a> is now open! If you'd like to give a talk, see it for details.</p>
-
-          <h1>Why?</h1>
-
-          <p>Roguelike games have been part of gaming culture for over 30 years! They have a deep and special place in
-            our hearts. There are so many fans across age groups and around the world that there should be a place for
-            all of them to get together and celebrate these unique games.</p>
-          <p>We were inspired to do this by the <a href="http://www.roguebasin.com/index.php?title=IRDC">International
-            Roguelike Development Conference</a> — and instead of a focus on development, this is for all of us — the
-            players!</p>
-
-          <p><img src="./ticket-front-25.png" alt="ticket image" style="width: 630px; max-width: 100%;" /></p>
-
-          <p><img src="./ticket-back.png" alt="ticket image back" style="width: 630px; max-width: 100%;" /></p>
-
-          <!--<h1 id="cfp" class="cover-heading">Call for presenters</h1>
-
-            <p>We have a lot of exciting presenters, but we'd like everyone to feel welcome to contribute! Are you interested in giving a talk (whether 2 minutes or 20 minutes), teaching a workshop, mentoring new players, or sharing something else? No speaking experience required; we would love to hear from you.</p>
-
-            <p class="lead"><a href="/cfp.html"><strong>Learn more and send your idea or talk proposal to us. →</strong></a></p>-->
-
-          <h1 id="policies" class="cover-heading">Our guidelines</h1>
-          <p>Roguelike Celebration is a friendly and respectful celebration that welcomes players of all levels of
-            experience (including no experience).</p>
-
-          <p>We have a code of conduct for all participants, since we're dedicated to a harassment-free conference
-            experience for everyone. <a href="./code.html">Our code of conduct.</a></p>
-
+      </nav>
+      <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
+        <div class="dropdown">
+          <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
+          <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
+            <li><a href="./">Intro</a></li>
+            <li><a href="./event2025.html">2025</a></li>
+            <li><a href="./who.html">About us</a></li>
+            <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
+            <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+            <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+            <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+            <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+            <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+            <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+            <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+            <li><a class="dropdown-item" href="./event.html">2016</a></li>
+          </ul>
         </div>
+      </nav>
+    </div>
+    
+    <div class="site-wrapper">
+      <div class="site-wrapper-inner">
+        <div class="cover-container">
+          <div class="inner cover">
+            <section class="giant-callout">
+              <span>Main Event</span><br/>
+              <span>Oct 25-26, 2025</span><br/>
+              <span>Online</span>
+              <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
+            </section>
+            <h1 id="thing" class="cover-heading">A celebration of roguelike games</h1>
+            
+            <div class="slidesContainer" id="slidesContainer">
+              <img class="mySlides" src="./photos/slideshow/1.jpg">
+              <img class="mySlides" src="./photos/slideshow/2.jpg">
+              <button class="w3-button w3-display-left" onclick="plusDivs(-1)">&#10094;</button>
+              <button class="w3-button w3-display-right" onclick="plusDivs(+1)">&#10095;</button>
+            </div>
 
-        <div class="mastfoot">
-          <div class="inner">
-            <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
+            <p>
+              Roguelike Celebration 2025 will be held on Saturday and Sunday <strong>October 25 - October 26, 2025</strong> as a <strong>virtual event</strong> in our custom-built multiplayer game/chat space. Talks will be streamed to Twitch and YouTube, and made available on YouTube shortly afterwards.
+            </p>
+
+            <p>The Roguelike Celebration is a yearly community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It's for fans, players, developers, scholars, and everyone else!</p>
+
+            <p>Roguelike games have been part of gaming culture for over 30 years and they have a deep and special place in our hearts. Over the last few years hundreds of roguelike fans got together to celebrate these games and their rich history, and we keep doing it again every October.</p>
+
+            <p>To make things feel particularly rogue-y, we host our virtual events in our own custom-built multiplayer game/chat space (<a href="https://github.com/Roguelike-Celebration/azure-mud">which is open source</a>). All you need to attend Roguelike Celebration is a web browser.</p>
+
+            <h1 id="updates" class="cover-heading">Want to get updates?</h1>
+
+            <h2>Email</h2>
+
+            <p>Sign up for occasional email announcements and updates about upcoming Roguelike Celebration events.</p>
+            <p><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Subscribe for updates!</a></p>
+
+            <h2>Twitter</h2>
+
+            <p>Use the <a href="https://twitter.com/search?q=%23roguelikecelebration&amp;f=liven">#RoguelikeCelebration</a> hashtag on twitter!
+            </p>
+
+            <p>Follow us on Twitter: <a href="https://twitter.com/roguelike_con">@roguelike_con</a></p>
+
+            <h2>Mastodon / The Fediverse</h2>
+            
+            <p>Follow us on Mastodon: <a rel="me" href="https://mastodon.gamedev.place/@roguelike_con">@roguelike_con@mastodon.gamedev.place</a></p>
+
+            <h2>Bluesky</h2>
+
+            <p>We're also on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
+
+            <h1 id="sponsors" class="cover-heading">Sponsors</h1>
+
+            <p style="text-align: center"><a href="https://www.artsandmedia.net"><img
+                  src="sponsors/IAM-Logo-White-Blue-Transparent-Background.png" alt="Independent Arts & Media logo" height="37" /></a>
+              <br />
+              Roguelike Celebration is <a href="https://en.wikipedia.org/wiki/Fiscal_sponsorship">fiscally sponsored</a> by <a href="https://www.artsandmedia.net">Independent Arts & Media</a>, a 501(c)(3) nonprofit organization.
+            <br />
+
+            <p>Is your organization interested in sponsoring Roguelike Celebration? Check out our <a
+                href="./sponsor.html">sponsorship
+                page</a>!</p>
+
+            <h1>Why?</h1>
+
+            <p>Roguelike games have been part of gaming culture for over 30 years! They have a deep and special place in
+              our hearts. There are so many fans across age groups and around the world that there should be a place for
+              all of them to get together and celebrate these unique games.</p>
+            <p>We were inspired to do this by the <a href="http://www.roguebasin.com/index.php?title=IRDC">International
+                Roguelike Development Conference</a> — and instead of a focus on development, this is for all of us — the
+              players!</p>
+
+            <p><img src="./ticket-front-25.png" alt="ticket image" style="width: 630px; max-width: 100%;" /></p>
+
+            <p><img src="./ticket-back.png" alt="ticket image back" style="width: 630px; max-width: 100%;" /></p>
+
+            <!--<h1 id="cfp" class="cover-heading">Call for presenters</h1>
+
+              <p>We have a lot of exciting presenters, but we'd like everyone to feel welcome to contribute! Are you interested in giving a talk (whether 2 minutes or 20 minutes), teaching a workshop, mentoring new players, or sharing something else? No speaking experience required; we would love to hear from you.</p>
+
+              <p class="lead"><a href="/cfp.html"><strong>Learn more and send your idea or talk proposal to us. →</strong></a></p>-->
+
+            <h1 id="policies" class="cover-heading">Our guidelines</h1>
+            <p>Roguelike Celebration is a friendly and respectful celebration that welcomes players of all levels of
+              experience (including no experience).</p>
+
+            <p>We have a code of conduct for all participants, since we're dedicated to a harassment-free conference
+              experience for everyone. <a href="./code.html">Our code of conduct.</a></p>
+
           </div>
+
+          <div class="mastfoot">
+            <div class="inner">
+              <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
+            </div>
+          </div>
+
         </div>
 
       </div>
 
     </div>
 
-  </div>
-
-  <!-- Bootstrap core JavaScript
-    ================================================== -->
-  <!-- Placed at the end of the document so the pages load faster -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <!-- Bootstrap core JavaScript
+      ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="./docs/assets/js/vendor/jquery.min.js"><\/script>')</script>
-  <script src="./dist/js/bootstrap.js"></script>
-  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-  <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
-</body>
-
+    <script src="./dist/js/bootstrap.js"></script>
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
+  </body>
 </html>

--- a/docs/obelisk.html
+++ b/docs/obelisk.html
@@ -30,12 +30,12 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
+
   <body>
     <nav><a href="https://roguelike.club">Roguelike Celebration</a></nav>
     <h1>The Obelisk: 2023 Links and Resources</h1>
     <p>The 2023 event took place in the virtual "Mall of Moria." People could share links for further reading on the "map obelisk" in the southern hallway. These are those notes, in order of upvotes.</p>
     <p><strong>Warning!</strong> These links have not been vetted. They are being passed directly from the obelisk to you. Click at your own risk.</p>
-    
   </body>
   
   <script>
@@ -45,16 +45,16 @@
     
     const parseLinks = (msg) =>  msg.replaceAll(/(https?:\/\/[^\s]+)/g, "<a href=\"$1\">$1</a>");
 
-  rawObeliskData.forEach(({message, author}) => {
-    const article = document.createElement("article");
-    const contents = document.createElement("p");
-    const authorElement = document.createElement("span");
-    authorElement.innerHTML = author;
-    contents.innerHTML = parseLinks(message);
-    contents.appendChild(document.createElement("br"));
-    contents.appendChild(authorElement);
-    article.appendChild(contents);
-    document.getElementsByTagName("body")[0].appendChild(article);
-  })
+    rawObeliskData.forEach(({message, author}) => {
+      const article = document.createElement("article");
+      const contents = document.createElement("p");
+      const authorElement = document.createElement("span");
+      authorElement.innerHTML = author;
+      contents.innerHTML = parseLinks(message);
+      contents.appendChild(document.createElement("br"));
+      contents.appendChild(authorElement);
+      article.appendChild(contents);
+      document.getElementsByTagName("body")[0].appendChild(article);
+    })
   </script>
-  </html>
+</html>

--- a/docs/schedule_js.html
+++ b/docs/schedule_js.html
@@ -28,22 +28,58 @@
   </head>
 
   <body>
-    <div class="container">
-      <div class="row">
-        <div class="col-xs-12 col-sm-6">
-          <h3>Roguelike Celebration @@@</h3>
-        </div>
-        <div class="col-xs-12 col-sm-6">
-          <ul class="masthead-nav nav pull-right">
-                  <li><a href="./">Intro</a></li>
-                  <li><a href="./event2018.html">2018</a></li>
-                  <li><a href="./event2017.html">2017</a></li>
-                  <li><a href="./event.html">2016</a></li>
-                  <li><a href="./who.html">About us</a></li>
-                  <li><a href="./roguelikes.html">Roguelikes?</a></li>
+    <div class="masthead clearfix">
+      <h3 class="masthead-brand">Roguelike Celebration</h3>
+      <nav class="hidden-xs hidden-sm">
+        <ul class="nav masthead-nav">
+          <li><a href="./">Intro</a></li>
+          <li><a href="./event2025.html">2025</a></li>
+          <li class="dropdown">
+              <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                Previous Years
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+                <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+                <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+                <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+                <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+                <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+                <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+                <li><a class="dropdown-item" href="./event.html">2016</a></li>
+              </ul>
+          </li>
+          <li><a href="./who.html">About us</a></li>
+          <li><a href="./code.html">CoC</a></li>
+          <li><a href="./sponsor.html">Sponsorship</a></li>
+          <li><a href="./roguelikes.html">Roguelikes?</a></li>
+        </ul>
+      </nav>
+      <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
+        <div class="dropdown">
+          <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
+          <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
+            <li><a href="./">Intro</a></li>
+            <li><a href="./event2025.html">2025</a></li>
+            <li><a href="./who.html">About us</a></li>
+            <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
+            <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+            <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+            <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+            <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+            <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+            <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+            <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+            <li><a class="dropdown-item" href="./event.html">2016</a></li>
           </ul>
         </div>
-      </div>
+      </nav>
+    </div>
 
       <div class="row">
         <div class="col-xs-12 col-sm-10">

--- a/docs/speakers2021.html
+++ b/docs/speakers2021.html
@@ -38,13 +38,15 @@
       <nav class="hidden-xs hidden-sm">
         <ul class="nav masthead-nav">
           <li><a href="./">Intro</a></li>
-          <li><a href="./event2023.html">2023</a></li>
+          <li><a href="./event2025.html">2025</a></li>
           <li class="active dropdown">
               <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 Previous Years
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -65,11 +67,13 @@
           <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
           <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
             <li><a href="./">Intro</a></li>
-            <li><a href="./event2023.html">2023</a></li>
+            <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>

--- a/docs/speakers2022.html
+++ b/docs/speakers2022.html
@@ -38,13 +38,15 @@
       <nav class="hidden-xs hidden-sm">
         <ul class="nav masthead-nav">
           <li><a href="./">Intro</a></li>
-          <li><a href="./event2023.html">2023</a></li>
+          <li><a href="./event2025.html">2025</a></li>
           <li class="active dropdown">
               <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 Previous Years
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -65,11 +67,13 @@
           <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
           <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
             <li><a href="./">Intro</a></li>
-            <li><a href="./event2023.html">2023</a></li>
+            <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>

--- a/docs/speakers2023.html
+++ b/docs/speakers2023.html
@@ -38,13 +38,15 @@
       <nav class="hidden-xs hidden-sm">
         <ul class="nav masthead-nav">
           <li><a href="./">Intro</a></li>
-          <li><a href="./event2023.html">2023</a></li>
+          <li><a href="./event2025.html">2025</a></li>
           <li class="active dropdown">
               <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 Previous Years
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
                 <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
                 <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
                 <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
@@ -65,11 +67,13 @@
           <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
           <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
             <li><a href="./">Intro</a></li>
-            <li><a href="./event2023.html">2023</a></li>
+            <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
             <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
             <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
             <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
             <li><a class="dropdown-item" href="./event2020.html">2020</a></li>

--- a/docs/speakers2024.html
+++ b/docs/speakers2024.html
@@ -76,6 +76,7 @@
           </li>
           <li><a href="./who.html">About us</a></li>
           <li><a href="./code.html">CoC</a></li>
+          <li><a href="./sponsor.html">Sponsorship</a></li>
           <li><a href="./roguelikes.html">Roguelikes?</a></li>
         </ul>
       </nav>
@@ -87,6 +88,7 @@
             <li><a href="./event2025.html">2025</a></li>
             <li><a href="./who.html">About us</a></li>
             <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
             <li><a href="./roguelikes.html">Roguelikes?</a></li>
             <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
             <li><a class="dropdown-item" href="./event2023.html">2023</a></li>

--- a/docs/speakers2024.html
+++ b/docs/speakers2024.html
@@ -33,23 +33,23 @@
 
   <body>
   
-  <template id="speaker_template"> 
-    <div class="speaker" >
-      <div class="link">
-        <a target="_blank" class="social_media_link">
-          <img class="headshot" />
-        </a>
+    <template id="speaker_template"> 
+      <div class="speaker" >
+        <div class="link">
+          <a target="_blank" class="social_media_link">
+            <img class="headshot" />
+          </a>
+        </div>
+        <div class="talk">
+          <a target="_blank" class="social_media_link">
+            <div class="speaker-name"></div>
+          </a>
+          <div><a class="talk_link"></a></div>
+          <div class="bio"></div>
+        </div>
       </div>
-      <div class="talk">
-        <a target="_blank" class="social_media_link">
-          <div class="speaker-name"></div>
-        </a>
-        <div><a class="talk_link"></a></div>
-        <div class="bio"></div>
-      </div>
-    </div>
-    <hr>
-  </template>
+      <hr>
+    </template>
   
     <div class="masthead clearfix">
       <h3 class="masthead-brand">Roguelike Celebration</h3>
@@ -107,16 +107,14 @@
         <div class="cover-container">
           <h1>2024 Speakers</h1>
           <div class="speakers">
-                     </div> <!-- speakers-->
+          </div> <!-- speakers-->
 
           <div class="mastfoot">
             <div class="inner">
               <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
             </div>
           </div>
-
         </div>
-
     </div>
 
     <!-- Bootstrap core JavaScript
@@ -130,37 +128,34 @@
     
     <script> // script to autofill speaker list
         
-    function tsvToSpeakerData(tsv){
-    
-      let string = tsv
-      let speakers = [];
-      let data =  string.split(/\r?\n/)
-      for (let row = 1; row < data.length; row++){
-        let entry = data[row].split(/\t/)
-        speakers.push({id: entry[0], name: entry[1], social_media_link: entry[2], headshot: entry[3], title:entry[4], description: entry[5], biography:entry[6], talk_id:entry[7]})
+      function tsvToSpeakerData(tsv) {
+        let string = tsv
+        let speakers = [];
+        let data =  string.split(/\r?\n/)
+        for (let row = 1; row < data.length; row++) {
+          let entry = data[row].split(/\t/)
+          speakers.push({id: entry[0], name: entry[1], social_media_link: entry[2], headshot: entry[3], title:entry[4], description: entry[5], biography:entry[6], talk_id:entry[7]})
+        }
+        console.log(speakers)
+        console.log(speakers.length)
+        let sorted = speakers.sort(function(speaker_1, speaker_2){ return speaker_1.name.localeCompare(speaker_2.name) });
+        return sorted
       }
-      console.log(speakers)
-      console.log(speakers.length)
-      let sorted = speakers.sort(function(speaker_1, speaker_2){  return speaker_1.name.localeCompare(speaker_2.name)});
-      return sorted
-    
-    }
 
-    var speaker_data = null;
+      var speaker_data = null;
 
-        var result = null;
-        var xmlhttp = new XMLHttpRequest();
-        xmlhttp.open("GET", "./speakers2024.tsv", false);
-        xmlhttp.send();
-        if (xmlhttp.status==200) {
-          result = xmlhttp.responseText;
-          
+      var result = null;
+      var xmlhttp = new XMLHttpRequest();
+      xmlhttp.open("GET", "./speakers2024.tsv", false);
+      xmlhttp.send();
+      if (xmlhttp.status==200) {
+        result = xmlhttp.responseText;
         speaker_data =  tsvToSpeakerData(result)
         
         let container = document.querySelector(".speakers")
         let template = document.querySelector("#speaker_template");
-        
-        speaker_data.forEach(function(speaker){
+      
+        speaker_data.forEach(function(speaker) {
           let speaker_element = template.content.cloneNode(true);
           speaker_element.querySelector(".speaker").id = speaker.id;
           speaker_element.querySelector(".headshot").src = ("./photos/2024/" + speaker.headshot);
@@ -170,16 +165,11 @@
           speaker_element.querySelector(".bio").innerHTML = speaker.biography;
           
           let td = speaker_element.querySelectorAll(".social_media_link").href = speaker.social_media_link;
-          
-          
           speaker_element.querySelectorAll(".social_media_link").forEach( (element) => {element.href = speaker.social_media_link});
           container.appendChild(speaker_element);
         })
   
-
-
-        
-        }
+      }
     </script>
 
   </body>

--- a/docs/sponsor.html
+++ b/docs/sponsor.html
@@ -1,183 +1,181 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-  <meta name="description" content="">
-  <meta name="author" content="">
-  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+    <title>Roguelike Celebration - Sponsorship</title>
 
-  <title>Roguelike Celebration - Sponsorship</title>
+    <!-- Bootstrap core CSS -->
+    <link href="./dist/css/bootstrap.min.css" rel="stylesheet">
 
-  <!-- Bootstrap core CSS -->
-  <link href="./dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <link href="./docs/assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
 
-  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-  <link href="./docs/assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <!-- Custom styles for this template -->
+    <link href="cover.css" rel="stylesheet">
 
-  <!-- Custom styles for this template -->
-  <link href="cover.css" rel="stylesheet">
+    <style>
+      h2 {
+        margin-top: 1.8em;
+      }
 
-  <style>
-    h2 {
-      margin-top: 1.8em;
-    }
+      .cover h3 {
+        font-size: 1.8em;
+        margin-top: 1.6em;
+      }
 
-    .cover h3 {
-      font-size: 1.8em;
-      margin-top: 1.6em;
-    }
+      strong {
+        font-weight: 900;
+      }
+    </style>
 
-    strong {
-      font-weight: 900;
-    }
-  </style>
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+      <![endif]-->
+  </head>
 
-  <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-  <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-</head>
+  <body>
 
-<body>
-
-  <div class="masthead clearfix">
-    <h3 class="masthead-brand">Roguelike Celebration</h3>
-    <nav class="hidden-xs hidden-sm">
-      <ul class="nav masthead-nav">
-        <li><a href="./">Intro</a></li>
-        <li><a href="./event2025.html">2025</a></li>
-        <li class="dropdown">
-            <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              Previous Years
-              <span class="caret"></span>
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="drop1">
-              <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-              <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-              <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-              <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-              <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-              <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-              <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-              <li><a class="dropdown-item" href="./event.html">2016</a></li>
-            </ul>
-        </li>
-        <li><a href="./who.html">About us</a></li>
-        <li><a href="./code.html">CoC</a></li>
-        <li class="active"><a href="./sponsor.html">Sponsorship</a></li>
-        <li><a href="./roguelikes.html">Roguelikes?</a></li>
-      </ul>
-    </nav>
-    <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
-      <div class="dropdown">
-        <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
-        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
+    <div class="masthead clearfix">
+      <h3 class="masthead-brand">Roguelike Celebration</h3>
+      <nav class="hidden-xs hidden-sm">
+        <ul class="nav masthead-nav">
           <li><a href="./">Intro</a></li>
           <li><a href="./event2025.html">2025</a></li>
+          <li class="dropdown">
+              <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                Previous Years
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+                <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+                <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+                <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+                <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+                <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+                <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+                <li><a class="dropdown-item" href="./event.html">2016</a></li>
+              </ul>
+          </li>
           <li><a href="./who.html">About us</a></li>
           <li><a href="./code.html">CoC</a></li>
-          <li><a href="./sponsor.html">Sponsorship</a></li>
+          <li class="active"><a href="./sponsor.html">Sponsorship</a></li>
           <li><a href="./roguelikes.html">Roguelikes?</a></li>
-          <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
-                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
-          <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
-          <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
-          <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
-          <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
-          <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
-          <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
-          <li><a class="dropdown-item" href="./event.html">2016</a></li>
         </ul>
-      </div>
-    </nav>
-  </div>
-
-  <div class="site-wrapper">
-
-    <div class="site-wrapper-inner">
-
-      <div class="cover-container">
-
-        <div class="inner cover">
-
-          <h1 id="seealso" class="cover-heading">Sponsorship</h1>
-
-          <p><strong>Thank you for your interest in sponsoring Roguelike Celebration! Please see <a href="https://drive.google.com/file/d/1A5i6jaiad8O20OeSrkurK1PAi4QHR_TT/view?usp=drive_link">our prospectus</a> for all details or read the summary below.</strong></p>
-
-          <p><strong>The Roguelike Celebration</strong> is a yearly community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It's for fans, players, developers, scholars, and everyone else!
-          </p>
-
-          <p>We have <strong>~600 ticketed attendees</strong> (roughly half of whom self-identify as game developers or run their own indie game studios), plus typically 2000+ viewers on our YouTube livestream and 500+ viewers on Twitch. Videos of the event are published to our YouTube channel with over 11,000 subscribers, 20,000 monthly views, and our most popular videos have been watched over 200,000 times!</p>
-
-          <h2>Benefits of Sponsorship</h2>
-
-          <p><strong>Your company</strong> will get visibility with a curious, passionate community with hundreds of independent game developers, software engineers, and enthusiasts from around the world. We are proud of the safe and inviting environment we’ve cultivated to bring together this unique group of humans from various backgrounds to talk, share, and learn about these weird games we all love.</p>
-
-          <p><strong>Your sponsorship</strong> will make Roguelike Celebration more diverse, helping with captioning, translation, server costs, art, and more. </p>
-          <h2>Contact</h2>
-          <p>Send us an email at <a
-              href="mailto:contact@roguelike.club?subject=I want to sponsor Roguelike Celebration!">contact@roguelike.club</a>
-            to get the conversation started!</p>
-
-          <h2>Sponsorship Levels</h2>
-
-          <h3>Community Sponsor ($500)</h3>
-          <ul>
-            <li>Logo on the website</li>
-            <li>Intro+outro slides</li>
-            <li>Mentioned during event</li>
+      </nav>
+      <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
+        <div class="dropdown">
+          <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
+          <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
+            <li><a href="./">Intro</a></li>
+            <li><a href="./event2025.html">2025</a></li>
+            <li><a href="./who.html">About us</a></li>
+            <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
+            <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+            <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+            <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+            <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+            <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+            <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+            <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+            <li><a class="dropdown-item" href="./event.html">2016</a></li>
           </ul>
-
-          <h3>Gold Sponsor ($2,000)</h3>
-          <ul>
-            <li>Everything included in Community Sponsorship</li>
-            <li>Larger logo on website, intro, outro slides</li>
-            <li>One social media + web post leading up to event</li>
-            <li>Verbal thanks during conference</li>
-            <li>Logo on all email communications</li>
-          </ul>
-
-          <h3>Partner Sponsor ($5,000)</h3>
-          <ul>
-            <li>Everything included in Gold Sponsorship</li>
-            <li>Largest logos on website, intro, outro slides</li>
-            <li>Additional social media + web post during event</li>
-            <li>On splash slide between talks</li>
-            <li><strong>Custom room</strong> in our conference Multi-User Dungeon!</li>
-          </ul>
-
-          <p>All prices in USD and subject to availability.</p>
-
-          Questions? Concerns? Suggestions? We'd love to hear from you at <a
-            href="mailto:contact@roguelike.club?subject=I want to sponsor Roguelike Celebration!">contact@roguelike.club</a>.
         </div>
+      </nav>
+    </div>
 
-        <div class="mastfoot">
-          <div class="inner">
-            <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
+    <div class="site-wrapper">
+
+      <div class="site-wrapper-inner">
+
+        <div class="cover-container">
+
+          <div class="inner cover">
+
+            <h1 id="seealso" class="cover-heading">Sponsorship</h1>
+
+            <p><strong>Thank you for your interest in sponsoring Roguelike Celebration! Please see <a href="https://drive.google.com/file/d/1A5i6jaiad8O20OeSrkurK1PAi4QHR_TT/view?usp=drive_link">our prospectus</a> for all details or read the summary below.</strong></p>
+
+            <p><strong>The Roguelike Celebration</strong> is a yearly community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It's for fans, players, developers, scholars, and everyone else!
+            </p>
+
+            <p>We have <strong>~600 ticketed attendees</strong> (roughly half of whom self-identify as game developers or run their own indie game studios), plus typically 2000+ viewers on our YouTube livestream and 500+ viewers on Twitch. Videos of the event are published to our YouTube channel with over 11,000 subscribers, 20,000 monthly views, and our most popular videos have been watched over 200,000 times!</p>
+
+            <h2>Benefits of Sponsorship</h2>
+
+            <p><strong>Your company</strong> will get visibility with a curious, passionate community with hundreds of independent game developers, software engineers, and enthusiasts from around the world. We are proud of the safe and inviting environment we’ve cultivated to bring together this unique group of humans from various backgrounds to talk, share, and learn about these weird games we all love.</p>
+
+            <p><strong>Your sponsorship</strong> will make Roguelike Celebration more diverse, helping with captioning, translation, server costs, art, and more. </p>
+            <h2>Contact</h2>
+            <p>Send us an email at <a
+                href="mailto:contact@roguelike.club?subject=I want to sponsor Roguelike Celebration!">contact@roguelike.club</a>
+              to get the conversation started!</p>
+
+            <h2>Sponsorship Levels</h2>
+
+            <h3>Community Sponsor ($500)</h3>
+            <ul>
+              <li>Logo on the website</li>
+              <li>Intro+outro slides</li>
+              <li>Mentioned during event</li>
+            </ul>
+
+            <h3>Gold Sponsor ($2,000)</h3>
+            <ul>
+              <li>Everything included in Community Sponsorship</li>
+              <li>Larger logo on website, intro, outro slides</li>
+              <li>One social media + web post leading up to event</li>
+              <li>Verbal thanks during conference</li>
+              <li>Logo on all email communications</li>
+            </ul>
+
+            <h3>Partner Sponsor ($5,000)</h3>
+            <ul>
+              <li>Everything included in Gold Sponsorship</li>
+              <li>Largest logos on website, intro, outro slides</li>
+              <li>Additional social media + web post during event</li>
+              <li>On splash slide between talks</li>
+              <li><strong>Custom room</strong> in our conference Multi-User Dungeon!</li>
+            </ul>
+
+            <p>All prices in USD and subject to availability.</p>
+
+            Questions? Concerns? Suggestions? We'd love to hear from you at <a
+              href="mailto:contact@roguelike.club?subject=I want to sponsor Roguelike Celebration!">contact@roguelike.club</a>.
           </div>
+
+          <div class="mastfoot">
+            <div class="inner">
+              <p>| ! % . . @ . @ . . @ . . . @ @ . \ \ \ \ \ . |</p>
+            </div>
+          </div>
+
         </div>
 
       </div>
 
     </div>
 
-  </div>
-
-  <!-- Bootstrap core JavaScript
-    ================================================== -->
-  <!-- Placed at the end of the document so the pages load faster -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="./docs/assets/js/vendor/jquery.min.js"><\/script>')</script>
-  <script src="/dist/js/bootstrap.min.js"></script>
-  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-  <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
-</body>
-
+    <!-- Bootstrap core JavaScript
+      ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="./docs/assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script src="/dist/js/bootstrap.min.js"></script>
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <script src="./docs/assets/js/ie10-viewport-bug-workaround.js"></script>
+  </body>
 </html>

--- a/snippets/navbar.html
+++ b/snippets/navbar.html
@@ -1,0 +1,60 @@
+    <!-- Common nav bar
+    
+    Copy-paste this into a page immediately under <body>, replacing the existing nav bar.
+
+    Then add `class="active"` to the appropriate <li> for that page. For pages under Previous Years,
+    add "active" to the `class="dropdown"` for Previous Years, so it's `class="active dropdown"`.
+    -->
+
+    <div class="masthead clearfix">
+      <h3 class="masthead-brand">Roguelike Celebration</h3>
+      <nav class="hidden-xs hidden-sm">
+        <ul class="nav masthead-nav">
+          <li><a href="./">Intro</a></li>
+          <li><a href="./event2025.html">2025</a></li>
+          <li class="dropdown">
+              <a id="drop1" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                Previous Years
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="drop1">
+                <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+                <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+                <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+                <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+                <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+                <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+                <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+                <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+                <li><a class="dropdown-item" href="./event.html">2016</a></li>
+              </ul>
+          </li>
+          <li><a href="./who.html">About us</a></li>
+          <li><a href="./code.html">CoC</a></li>
+          <li><a href="./sponsor.html">Sponsorship</a></li>
+          <li><a href="./roguelikes.html">Roguelikes?</a></li>
+        </ul>
+      </nav>
+      <nav class="masthead-nav visible-xs-inline-block visible-sm-inline-block">
+        <div class="dropdown">
+          <a id="hamburger" class="dropdown-toggle" href="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-menu-hamburger"></span></a>
+          <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="hamburger">
+            <li><a href="./">Intro</a></li>
+            <li><a href="./event2025.html">2025</a></li>
+            <li><a href="./who.html">About us</a></li>
+            <li><a href="./code.html">CoC</a></li>
+            <li><a href="./sponsor.html">Sponsorship</a></li>
+            <li><a href="./roguelikes.html">Roguelikes?</a></li>
+            <li><a class="dropdown-item" href="./event2024.html">2024</a></li>
+            <li><a class="dropdown-item" href="./event2023.html">2023</a></li>
+            <li><a class="dropdown-item" href="./event2022.html">2022</a></li>
+            <li><a class="dropdown-item" href="./event2021.html">2021</a></li>
+            <li><a class="dropdown-item" href="./event2020.html">2020</a></li>
+            <li><a class="dropdown-item" href="./event2019.html">2019</a></li>
+            <li><a class="dropdown-item" href="./event2018.html">2018</a></li>
+            <li><a class="dropdown-item" href="./event2017.html">2017</a></li>
+            <li><a class="dropdown-item" href="./event.html">2016</a></li>
+          </ul>
+        </div>
+      </nav>
+    </div>


### PR DESCRIPTION
A few nav bar fixes, plus code formatting.

Adds missing Sponsorship item to the nav bar on event2025.

Copies the nav bar HTML out to a `snippets/navbar.html` for easier copy-pasting. Makes HTML indentation more uniform so copy-pastes won't introduce spurious whitespace-only diffs.

Indents the HTML in index.html and sponsor.html to have `<head>` and `<body>` indented under `<html>`, consistent with the rest of the pages. Makes copy-pasting and diffs between files easier.

Updates the nav bar for the older `speakers202{1,2,3}.html` pages that I missed earlier.

Makes the individual year menu items in the Previous Years submenu active when viewing those pages, by adding `class="active"` to the submenu `<li>` tags for them.