### PR TITLE
Fix "Add big button to submit talk proposal to front" regression

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -149,6 +149,7 @@
               <span>Oct 25-26, 2025</span><br/>
               <span>Online</span>
               <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
+              <div><a href="./cfp.html" class="btn btn-success btn-lg" role="button">Submit a talk proposal!</a></div>
             </section>
             <h1 id="thing" class="cover-heading">A celebration of roguelike games</h1>
             


### PR DESCRIPTION
The recent addition of the big "submit talk" button to index.html in cc47831aaa34ff47c71f got accidentally undone by the HTML reindentation and nav-bar fixes in 1b15c43ee040ae (PR https://github.com/Roguelike-Celebration/roguelike.club/pull/63), due to a bad merge conflict resolution when I rebased that PR.

This PR undoes that regression, by re-adding the button (with aligned indentation).