### PR TITLE
Big/fixed video links for 2024, 2023, 2016, and index

### DIFF
--- a/docs/event.html
+++ b/docs/event.html
@@ -93,7 +93,7 @@
 
             <h1 class="cover-heading">Talk videos</h1>
 
-            <p class="lead">Videos from the 2016 event are on the <a href="https://archive.org/details/RoguelikeCelebration2016">Internet Archive</a> and <a href="https://www.youtube.com/channel/UCsCqXksJuAkfZRtnW5Pq1mw/videos?shelf_id=0&view=0&sort=dd">YouTube</a>.</p>
+            <p class="lead">Videos from the 2016 event are on the <a href="https://archive.org/details/RoguelikeCelebration2016">Internet Archive</a> and <a href="https://www.youtube.com/playlist?list=PLi7jNGNQhwdgIH5-ynAEC6e50MUDHolU3">YouTube</a>.</p>
 
             <ul>
                 <li><a href="https://www.youtube.com/watch?v=ZMRsScwdPcE"><strong>Tarn and Zach Adams</strong></a> — The creators of Dwarf Fortress</li>

--- a/docs/event2023.html
+++ b/docs/event2023.html
@@ -113,6 +113,9 @@
           <p>
             The full stream recording is available on our channel on YouTube (<a href="https://www.youtube.com/watch?v=Hv-9Au3bySI">Preview</a>, <a href="https://www.youtube.com/watch?v=cYQr-m9ltXM&t=2s">Saturday</a>, <a href="https://www.youtube.com/watch?v=CZYon-aK4O0">Sunday</a>). You can also watch <a href="https://www.youtube.com/playlist?list=PLi7jNGNQhwdhsv4db-TsTI32mGSx8chGw">individual talk videos</a>.
           </p>
+          <p>
+            <a href="https://www.youtube.com/playlist?list=PLi7jNGNQhwdhsv4db-TsTI32mGSx8chGw" class="btn btn-success btn-lg" role="button">Watch talk recordings on YouTube</a>
+          </p>
 
           <h1>Schedule</h1>
 

--- a/docs/event2024.html
+++ b/docs/event2024.html
@@ -116,13 +116,7 @@
           <h1>Roguelike Celebration 2024</h1>
 
           <div class="inner cover">
-            <section class="giant-callout">
-              <span>Main Event</span><br/>
-              <span>Oct 19-20, 2024</span><br/>
-              <span>Online</span>
-              <div><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Join the mailing list!</a></div>
-
-            </section>
+            <p><a href="https://www.youtube.com/playlist?list=PLi7jNGNQhwdiwa-gDxU_Mu_qqsbxaaBh_" class="btn btn-success btn-lg" role="button">Watch talk recordings on YouTube</a></p>
           </div>
 
           <h1>When and Where?</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -192,6 +192,10 @@
 
             <p>We're also on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
 
+            <h2>YouTube</h2>
+
+            <p>Watch videos of previous talks on <a href="https://www.youtube.com/@roguelikecelebration">our YouTube channel</a>.</p>
+
             <h1 id="sponsors" class="cover-heading">Sponsors</h1>
 
             <p style="text-align: center"><a href="https://www.artsandmedia.net"><img


### PR DESCRIPTION
Fix the 2016 videos link, and make video links more prominent in 2023, 2024, and index pages. Addresses https://github.com/Roguelike-Celebration/roguelike.club/issues/68.

* Fix YouTube playlist link on 2016 event page.
* Add big "watch talk recordings" button on 2023 to make it easier to find (vs. the "YouTube" link in body text).
* Add big "watch talk recordings" button on 2024 page like older years, replacing the giant callout with dates and "join mailing list', which looks more like a coming-soon announcement.
* Add link to YouTube channel on index.html, in the "more info" section.