### PR TITLE
Demote Twitter on index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -177,20 +177,17 @@
             <p>Sign up for occasional email announcements and updates about upcoming Roguelike Celebration events.</p>
             <p><a href="https://buttondown.email/RoguelikeCelebration" class="btn btn-success btn-lg" role="button" target="_blank" rel="nofollow noopener noreferrer">Subscribe for updates!</a></p>
 
-            <h2>Twitter</h2>
+            <h2>Bluesky</h2>
 
-            <p>Use the <a href="https://twitter.com/search?q=%23roguelikecelebration&amp;f=liven">#RoguelikeCelebration</a> hashtag on twitter!
-            </p>
-
-            <p>Follow us on Twitter: <a href="https://twitter.com/roguelike_con">@roguelike_con</a></p>
+            <p>Follow us on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
 
             <h2>Mastodon / The Fediverse</h2>
             
-            <p>Follow us on Mastodon: <a rel="me" href="https://mastodon.gamedev.place/@roguelike_con">@roguelike_con@mastodon.gamedev.place</a></p>
+            <p>Or find us on Mastodon: <a rel="me" href="https://mastodon.gamedev.place/@roguelike_con">@roguelike_con@mastodon.gamedev.place</a></p>
 
-            <h2>Bluesky</h2>
+            <h2>Twitter</h2>
 
-            <p>We're also on Bluesky: <a href="https://bsky.app/profile/roguelike.club">@roguelike.club</a></p>
+            <p>We're also on Twitter: <a href="https://twitter.com/roguelike_con">@roguelike_con</a>, hashtag <a href="https://twitter.com/search?q=%23roguelikecelebration&amp;f=liven">#RoguelikeCelebration</a></p>
 
             <h1 id="sponsors" class="cover-heading">Sponsors</h1>
 


### PR DESCRIPTION
Move Twitter to the bottom of the social media links, and Bluesky to the top, to reflect our current usage.